### PR TITLE
Adds 'small' to list of valid markups

### DIFF
--- a/lib/utils/tag-names.js
+++ b/lib/utils/tag-names.js
@@ -17,7 +17,7 @@ const LIST_SECTION_TAG_NAMES = [
 ].map(normalizeTagName);
 
 const MARKUP_TYPES = [
-  'b', 'i', 'strong', 'em', 'a', 'u', 'sub', 'sup', 's', 'code'
+  'b', 'i', 'strong', 'em', 'a', 'u', 'sub', 'sup', 's', 'code', 'small'
 ].map(normalizeTagName);
 
 function contains(array, item) {

--- a/tests/unit/renderers/0-3-test.js
+++ b/tests/unit/renderers/0-3-test.js
@@ -99,6 +99,20 @@ test('renders markup section "aside"', (assert) => {
   assert.equal(outerHTML(sectionEl), '<aside>hello world</aside>');
 });
 
+test('renders markup "small', (assert) => {
+  let mobiledoc = createSimpleMobiledoc({
+    version: MOBILEDOC_VERSION_0_3_1,
+    markup: ['small'],
+    text: 'small world'
+  });
+  let { result: rendered } = renderer.render(mobiledoc);
+  assert.equal(childNodesLength(rendered), 1,
+               'renders 1 section');
+  let sectionEl = rendered.firstChild;
+
+  assert.equal(innerHTML(sectionEl), '<small>small world</small>');
+});
+
 test('renders a mobiledoc with simple (no attributes) markup', (assert) => {
   let mobiledoc = createSimpleMobiledoc({
     version: MOBILEDOC_VERSION_0_3_1,


### PR DESCRIPTION
`<small>` perhaps doesn't have "semantic" meaning per say, but approximately as much meaning as `<b>` or `<i>`