### PR TITLE
Replace tab characters with emspaces

### DIFF
--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -1,10 +1,12 @@
-function addHTMLSpaces(text) {
-  let nbsp = '\u00A0';
-  return text.replace(/  /g, ' ' + nbsp);
+const NBSP = '\u00A0';
+const EMSP = '\u2003';
+
+function prepareText(text) {
+  return text.replace(/  /g, ' ' + NBSP).replace(/\t/g, EMSP);
 }
 
 export function createTextNode(dom, text) {
-  return dom.createTextNode(addHTMLSpaces(text));
+  return dom.createTextNode(prepareText(text));
 }
 
 export function normalizeTagName(tagName) {

--- a/tests/unit/renderers/0-2-test.js
+++ b/tests/unit/renderers/0-2-test.js
@@ -473,6 +473,24 @@ test('multiple spaces should preserve whitespace with nbsps', (assert) => {
   assert.equal(textNode.nodeValue, expectedText, 'renders the text');
 });
 
+test('replaces tab characters with EM SPACE', (assert) => {
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [], // markers
+      [   // sections
+        [MARKUP_SECTION_TYPE, 'P', [
+          [[], 0, "\tHello	world"]]
+        ]
+      ]
+    ]
+  };
+
+  let { result: rendered } = renderer.render(mobiledoc);
+  let elementNode = rendered.firstChild.firstChild;
+  assert.equal(elementNode.nodeValue, '\u2003Hello\u2003world', 'replaces tabs with &emsp;');
+});
+
 test('throws when given unexpected mobiledoc version', (assert) => {
   let mobiledoc = {
     version: '0.1.0',


### PR DESCRIPTION
This PR makes the logic for rendering tab characters consistent between `mobiledoc-kit` and `mobiledoc-dom-renderer`. All tab characters should be replaced with emspace: `\u2003`.

Original PR to the `mobiledoc-kit` where this was added is [here](https://github.com/bustle/mobiledoc-kit/pull/254).