### PR TITLE
Allow all data-* attributes

### DIFF
--- a/lib/utils/render-utils.js
+++ b/lib/utils/render-utils.js
@@ -5,12 +5,8 @@ import {
   sanitizeHref
 } from './sanitization-utils';
 
-export const VALID_ATTRIBUTES = [
-  'data-md-text-align'
-];
-
 function _isValidAttribute(attr) {
-  return VALID_ATTRIBUTES.indexOf(attr) !== -1;
+  return typeof attr === 'string' && attr.match(/^data-([0-9a-zA-Z-])+$/);
 }
 
 function handleMarkupSectionAttribute(element, attributeKey, attributeValue) {

--- a/tests/unit/renderers/0-3-test.js
+++ b/tests/unit/renderers/0-3-test.js
@@ -93,12 +93,12 @@ test('throws when given invalid attribute', (assert) => {
     version: MOBILEDOC_VERSION_0_3_2,
     sectionName: 'p',
     text: 'hello world',
-    attributes: { 'data-md-bad-attribute': 'something' }
+    attributes: { 'bad-attribute': 'something' }
   });
 
   assert.throws(
     () => { renderer.render(mobiledoc) }, // jshint ignore: line
-    new RegExp(`Cannot use attribute: data-md-bad-attribute`)
+    new RegExp(`Cannot use attribute: bad-attribute`)
   );
 });
 


### PR DESCRIPTION
Hi, would you consider to allow all sort of data attributes assigned to the markup elements?
I really need that feature and i think it will be very usefull for others too.
Closes https://github.com/bustle/mobiledoc-kit/issues/787